### PR TITLE
Suspend teleport-operator App CR for HelmRelease migration

### DIFF
--- a/kustomize/teleport-operator.yaml
+++ b/kustomize/teleport-operator.yaml
@@ -3,6 +3,7 @@ kind: App
 metadata:
   annotations:
     chart-operator.giantswarm.io/force-helm-upgrade: "true"
+    app-operator.giantswarm.io/paused: "true"
   labels:
     app-operator.giantswarm.io/version: 0.0.0
   name: teleport-operator


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/35076